### PR TITLE
improving speed performance of shiny app

### DIFF
--- a/code/3.prepare_data_for_shiny.R
+++ b/code/3.prepare_data_for_shiny.R
@@ -1,23 +1,24 @@
-# ***********************************************************************************************
-#### installing, loading libraries ####
-library("utils")
+# ------------------------------------- ATTENTION: THIS FILE WILL GET SOURCED ---------------------
+# ----------------------------------------------- installing, loading libraries -------------------
+# library("utils")
 
 packages <- c("here", "shiny", "zip", "sf", "tmap", "tmaptools", "ggplot2", "dplyr", "shinydashboard", "leaflet")
 
 ### install if necessary
-lapply(packages, 
-       function(x)
-       {
-         if(!(x %in% installed.packages()) | x %in% old.packages())
+if (F){# just run by hand to limit time that sourcing takes
+  lapply(packages, 
+         function(x)
          {
-           install.packages(x)  
-         }
-       })
+           if(!(x %in% installed.packages()) | x %in% old.packages())
+           {
+             install.packages(x)  
+           }
+         })
+}
 
 lapply(packages, require, character.only = T)
 
-# **********************************************************************************************
-#### D E F I N I T I O N S ####
+# ---------------------------------------------- D E F I N I T I O N S --------------------------
 #rm(list=ls(all=TRUE))
 options(scipen = 999) # no scientific numbering
 subfolder <- zip_list(here("data", "raw", "shape_germany_bundesland_landkreis.zip"))$filename[1]
@@ -27,8 +28,7 @@ file_ger_shape_state <- here("data", "raw", "shape_ger", subfolder, "vg2500", "v
 file_ger_shape_county <- here("data", "raw", "shape_ger", subfolder, "vg2500", "vg2500_krs.shp")
 
 
-# ***********************************************************************************************
-#### load data and prepare data####
+# ------------------------------------------- load data and prepare data ---------------------------
 # read all data files
 data_state <- read.csv2(here("data", "processed", paste0("data_state", ".csv")), row.names = NULL, encoding = "UTF-8", stringsAsFactors = FALSE)
 data_state_combined_all_sources <- read.csv2(here("data", "processed", paste0("data_state_combined_all_sources", ".csv")), row.names = NULL, encoding = "UTF-8", stringsAsFactors = FALSE)
@@ -74,7 +74,7 @@ names(ger_shape_county)[names(ger_shape_county) == "RS"] <- "ags"
 ger_shape_county$ags <- as.numeric(ger_shape_county$ags)
 ger_shape_state$ags <- as.numeric(ger_shape_state$ags)
 
-# ***********************************************************************************************
+# -----------------------------------------------------------------------------------------------
 #### merge shape file after aggregation ####
 ## general maps for data exploration
 map_data_state <- left_join(ger_shape_state, data_state, by = c("ags" = "ags_federal_state"))
@@ -110,16 +110,55 @@ data_state[is.na(data_state$ags_federal_state),]
 map_data_state_combined_all_sources[is.na(map_data_state_combined_all_sources$ags_federal_state),]
 map_data_state_yearly_combined_all_sources[is.na(map_data_state_yearly_combined_all_sources$ags_federal_state),]
 
-saveRDS(map_data_state_combined_all_sources, file = here::here("data", "processed","map_data_state_combined_all_sources.rds"))
-saveRDS(map_data_state_combined_all_sources, file =  here::here("data", "processed","map_data_state_combined_all_sources.rds"))
-saveRDS(map_data_county_combined_all_sources, file =  here::here("data", "processed","map_data_county_combined_all_sources.rds"))
-saveRDS(map_data_state_yearly_combined_all_sources, file =  here::here("data", "processed","map_data_state_yearly_combined_all_sources.rds"))
-saveRDS(map_data_county_yearly_combined_all_sources, file =  here::here("data", "processed","map_data_county_yearly_combined_all_sources.rds"))
-saveRDS(map_data_state, file = here::here("data", "processed","map_data_state.rds"))
-saveRDS(map_data_county, file =  here::here("data", "processed","map_data_county.rds"))
-saveRDS(map_data_state_yearly, file =  here::here("data", "processed","map_data_state_yearly.rds"))
-saveRDS(map_data_county_yearly, file =  here::here("data", "processed","map_data_county_yearly.rds"))
+#saveRDS(map_data_state_combined_all_sources, file = here::here("data", "processed","map_data_state_combined_all_sources.rds"))
+#saveRDS(map_data_county_combined_all_sources, file =  here::here("data", "processed","map_data_county_combined_all_sources.rds"))
+#saveRDS(map_data_state_yearly_combined_all_sources, file =  here::here("data", "processed","map_data_state_yearly_combined_all_sources.rds"))
+#saveRDS(map_data_county_yearly_combined_all_sources, file =  here::here("data", "processed","map_data_county_yearly_combined_all_sources.rds"))
+#saveRDS(map_data_state, file = here::here("data", "processed","map_data_state.rds"))
+#saveRDS(map_data_county, file =  here::here("data", "processed","map_data_county.rds"))
+#saveRDS(map_data_state_yearly, file =  here::here("data", "processed","map_data_state_yearly.rds"))
+#saveRDS(map_data_county_yearly, file =  here::here("data", "processed","map_data_county_yearly.rds"))
 
 # related to offshore (always if ags_federal_state is missing)
 
 ## ...
+
+# ---------------------------------- performance improvement: break down files to energy type ----
+# ------------------ map data state ----
+## stock
+list_types <- unique(map_data_state$EinheitenTyp)
+for (i in list_types)
+{
+  assign(paste0(deparse(substitute(map_data_state)), "_", i), map_data_state %>%
+                            filter(EinheitenTyp == i))
+}
+
+
+## flow
+list_types <- unique(map_data_state_yearly$EinheitenTyp)
+for (i in list_types)
+{
+  assign(paste0(deparse(substitute(map_data_state_yearly)), "_", i), map_data_state_yearly %>%
+           filter(EinheitenTyp == i))
+}
+
+
+
+# ------------------ map data county ----
+## stock
+list_types <- unique(map_data_county$EinheitenTyp)
+for (i in list_types)
+{
+  assign(paste0(deparse(substitute(map_data_county)), "_", i), map_data_county %>%
+           filter(EinheitenTyp == i))
+}
+
+
+## flow
+list_types <- unique(map_data_county_yearly$EinheitenTyp)
+for (i in list_types)
+{
+  assign(paste0(deparse(substitute(map_data_county_yearly)), "_", i), map_data_county_yearly %>%
+           filter(EinheitenTyp == i))
+}
+

--- a/ui.R
+++ b/ui.R
@@ -1,38 +1,3 @@
-library("utils")
-library("here")
-library("shiny")
-library("zip")
-library("sf")
-library("tmap")
-library("tmaptools")
-library("ggplot2")
-library("dplyr")
-library("shinydashboard")
-library("leaflet")
-
-
-# -------------------------------------------- load final data  ---------------------------------
-map_data_state_combined_all_sources <- readRDS(here::here("data","processed","map_data_state_combined_all_sources.rds"))
-map_data_state_yearly_combined_all_sources <- readRDS(here::here("data","processed","map_data_state_yearly_combined_all_sources.rds"))
-map_data_county_combined_all_sources <- readRDS(here::here("data","processed","map_data_county_combined_all_sources.rds"))
-map_data_county_yearly_combined_all_sources <- readRDS(here::here("data","processed","map_data_county_yearly_combined_all_sources.rds"))
-map_data_county <- readRDS(here::here("data","processed","map_data_county.rds"))
-map_data_state <- readRDS(here::here("data","processed","map_data_state.rds"))
-map_data_county_yearly <- readRDS(here::here("data","processed","map_data_county_yearly.rds"))
-map_data_state_yearly <- readRDS(here::here("data","processed","map_data_state_yearly.rds"))
-
-data_state_yearly <- read.csv2(here::here("data","processed","data_state_yearly.csv"), row.names = NULL, encoding = "UTF-8", stringsAsFactors = FALSE)
-new_data_state <- subset(data_state_yearly, start_year >= "2000")
-
-
-# ---------------------------------- First Story on Solar and Income ------------------------------
-## load
-data_state_solar_income_2015 <- read.csv2(here::here("data", "processed", paste0("data_state_solar_income_2015", ".csv")), row.names = NULL, encoding = "UTF-8", stringsAsFactors = FALSE)
-## load
-data_county_solar_income_2015 <- read.csv2(here::here("data", "processed", paste0("data_county_solar_income_2015", ".csv")), row.names = NULL, encoding = "UTF-8", stringsAsFactors = FALSE)
-
-
-
 # -------------------------------------------- create ui  -----------------------------------
 ui <- dashboardPage(
   dashboardHeader(title = "Dashboard"),


### PR DESCRIPTION
Kicks out the rds files and separates state and county-level data files into the energy types. Therefore, the Shiny app does not need to load one big file when it just wants to access a specific energy type. Loading time should be reduced to about 1/10th.